### PR TITLE
Add debug dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "watchify": "3.7.0"
   },
   "dependencies": {
+    "debug": "2.2.0",
     "lowscore": "1.8.0",
     "parse-function": "2.3.0",
     "socket.io-client": "1.4.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-server-side",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Without the debug module, Karma will fail when performing `npm test`:

```
> karma-server-side@1.5.1 test ./karma-server-side
> karma start --single-run

02 07 2016 19:24:06.559:ERROR [config]: Error in config file!
 { [Error: Cannot find module 'debug'] code: 'MODULE_NOT_FOUND' }
Error: Cannot find module 'debug'
```
