### PR TITLE
Serve socket.io client

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,23 @@ var debug = require('debug')('karma-server-side');
 var originalRequireCache;
 var context = {};
 var cwd = process.cwd();
+var path = require('path');
 
 function isLocalModule(filename) {
   return filename.indexOf(cwd) != -1 && !filename.match(/[/\\]node_modules[/\\]/);
 }
 
-function createFramework(emitter, io) {
+function createFramework(emitter, io, files) {
+  var p = path.join(require.resolve('karma'), '../../node_modules/socket.io/node_modules',
+     '/socket.io-client/socket.io.js');
+  // make io lib available in context
+  files.unshift({
+    pattern: p,
+    included: true,
+    served: true,
+  });
+
+
   emitter.on('run_start', function () {
     // Store originalRequireCache once when Karma starts.
     // To prevent the situation where second 'run_start' (e.g. user clicked karma Debug button)
@@ -91,7 +102,7 @@ function serialiseError(error) {
   return s;
 }
 
-createFramework.$inject = ['emitter', 'socketServer'];
+createFramework.$inject = ['emitter', 'socketServer', 'config.files'];
 
 module.exports = {
   'framework:server-side': [ 'factory', createFramework ]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "karma start --single-run"
+    "test": "karma start --single-run",
+    "karma": "karma start"
   },
   "author": "Tim Macfarlane <timmacfarlane@gmail.com>",
   "license": "ISC",
@@ -25,7 +26,6 @@
   "dependencies": {
     "debug": "2.2.0",
     "lowscore": "1.8.1",
-    "parse-function": "2.3.2",
-    "socket.io-client": "1.4.8"
+    "parse-function": "2.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-server-side",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/reqres.js
+++ b/reqres.js
@@ -1,4 +1,3 @@
-var io = require('socket.io-client');
 var findUrlRoot = require('./findUrlRoot');
 
 var messages = {};


### PR DESCRIPTION
By serving socket.io-client's `io` function in Karma's context iFrame, we avoid requiring the client in the bundled browser export, which means we can save time (e.g., useful when tests have to be transpiled and browserified, so we don't have to do it for the socket.io-client library). 
